### PR TITLE
Added support for webPhar rewrite function

### DIFF
--- a/src/lib/Phine/Phar/Stub.php
+++ b/src/lib/Phine/Phar/Stub.php
@@ -105,6 +105,13 @@ class Stub
     private $require = array();
 
     /**
+     * The rewrite function.
+     *
+     * @var string
+     */
+    private $rewriteFunction = '';
+
+    /**
      * The "self extracting" flag.
      *
      * @var boolean
@@ -268,6 +275,11 @@ STUB;
         }
 
         if ($this->webPhar) {
+
+            if ('' !== $this->rewriteFunction) {
+                $stub .= $this->rewriteFunction . "\n";
+            }
+
             $stub .= sprintf(
                 "Phar::webPhar(%s, %s, %s, %s, %s);\n",
                 $export($this->webPhar[0]),
@@ -564,6 +576,37 @@ STUB;
     public function setBanner($banner)
     {
         $this->banner = $banner;
+
+        return $this;
+    }
+
+    /**
+     * Sets the rewrite function.
+     *
+     * This method will set the rewrite function that is used for the
+     * `Phar::webPhar()` method.
+     *
+     *     $stub->setRewriteFunction('rewrite', "function rewrite(\$path) {
+     *         return 'index.php';
+     *     }");
+     *
+     * @param string $name The function name.
+     * @param string $function The function itself.
+     *
+     * @return Stub The stub generator.
+     *
+     * @api
+     */
+    public function setRewriteFunction($name, $function)
+    {
+        // Make sure the webPhar values are correct
+        if (null === $this->webPhar) {
+            $this->webPhar(null, 'index.php', null, array(), $name);
+        }
+
+        $this->webPhar[4] = $name;
+
+        $this->rewriteFunction = $function;
 
         return $this;
     }

--- a/src/tests/Phine/Phar/Tests/StubTest.php
+++ b/src/tests/Phine/Phar/Tests/StubTest.php
@@ -98,6 +98,12 @@ BANNER
         // inject a mapping alias
         Property::set($this->stub, 'mapPhar', 'test.phar');
 
+        // inject web phar rewrite function
+        Property::set($this->stub, 'rewriteFunction',
+        "function rewrite(\$path) {
+            return 'index.php';
+        }");
+
         // inject web phar settings
         Property::set(
             $this->stub,
@@ -178,6 +184,9 @@ BANNER
 if (class_exists('Phar')) {
 \$include = 'phar://' . __FILE__;
 Phar::mapPhar('test.phar');
+function rewrite(\$path) {
+            return 'index.php';
+        }
 Phar::webPhar('web.phar', 'index.php', '404.php', array (
   'phps' => 1,
 ), 'rewrite');
@@ -397,6 +406,66 @@ STUB
             '#!test',
             Property::get($this->stub, 'shebang'),
             'The shebang line should be set.'
+        );
+    }
+
+    /**
+     * Make sure we can set the rewrite function.
+     */
+    public function testSetRewriteFunction()
+    {
+        $rewriteFunction = "function rewrite(\$path) {
+            return 'index.php';
+        }";
+
+        $this->assertSame(
+            $this->stub,
+            $this->stub->setRewriteFunction('rewrite',
+            $rewriteFunction),
+            'The method should return its object.'
+        );
+
+        $this->assertEquals(
+            $rewriteFunction,
+            Property::get($this->stub, 'rewriteFunction'),
+            'The rewrite function should be set.'
+        );
+    }
+
+    /**
+     * Make sure setRewriteFunction overwrites wrong function parameter.
+     */
+    public function testSetRewriteFunctionParameterOverride()
+    {
+        $this->stub->webPhar('alias', 'index.php', null, array(), 'wrong');
+
+        $this->assertSame(
+            array(
+                 'alias',
+                 'index.php',
+                 null,
+                 array(),
+                 'wrong'
+            ),
+            Property::get($this->stub, 'webPhar'),
+            'The web phar settings are incorrect.'
+        );
+
+        $this->stub->setRewriteFunction('rewrite',
+            "function rewrite(\$path) {
+                return 'index.php';
+            }");
+
+        $this->assertSame(
+            array(
+                 'alias',
+                 'index.php',
+                 null,
+                 array(),
+                 'rewrite'
+            ),
+            Property::get($this->stub, 'webPhar'),
+            'The setRewriteFunction method should change rewrite function.'
         );
     }
 


### PR DESCRIPTION
Hi there!

Incredible code quality! I gave my very best and hope it's good enough for you :-)

I had the problem that I could not add any rewrite function before your `Stub` helper class generated some `Phar::webPhar()` code. I had to help myself using the banner and replacing the first occurrence of `*/` which obviously worked fine and did the job for me but I thought I wanted to give something back :-)

So instead of hacking something like that:

``` php
$rewrite_function = "function rewrite_function(\$path) {
    return 'index.php';
}";

$stub = Phine\Phar\Stub::create()
    ->webPhar(null, 'index.php', null, array(), 'rewrite_function')
    ->getStub();

$stub = preg_replace('/(\*\/)/', '$1' . "\n\n" . $rewrite_function, $stub, 1);

$builder->setStub($stub);
```

you can can now do this:

``` php
$rewrite_function = "function rewrite_function(\$path) {
    return 'index.php';
}";

$stub = Phine\Phar\Stub::create()
    ->webPhar(null, 'index.php', null, array())
    ->setRewriteFunction('rewrite_function', $rewrite_function)
    ->getStub();

$builder->setStub($stub);
```

Hope you like it :-)
